### PR TITLE
ayatana-settings: Add colour scheme handler

### DIFF
--- a/ayatana-settings
+++ b/ayatana-settings
@@ -46,8 +46,13 @@ class AyatanaSettings:
 
         buildApp(self)
 
+        self.pGnomeSettings = Gio.Settings.new ('org.gnome.desktop.interface')
+        self.pGnomeSettings.connect ('changed::color-scheme', self.onColorSchemeChanged)
+        self.onColorSchemeChanged (self.pGnomeSettings, 'color-scheme')
+
         self.bSystemd = isSystemd()
         self.bInit = False
+        
         try:
             self.sDesktop = os.environ['XDG_CURRENT_DESKTOP']
         except KeyError:
@@ -337,6 +342,12 @@ class AyatanaSettings:
             lItems.append(lRow[0])
 
         self.pSettingsNotifications.set_strv('filter-list', lItems)
+
+    def onColorSchemeChanged (self, pSettings, sKey):
+
+        sColorScheme = pSettings.get_string (sKey)
+        bDark = (sColorScheme == 'prefer-dark')
+        Gtk.Settings.get_default().props.gtk_application_prefer_dark_theme = bDark
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
This is a proof of concept for the Display Indicator:

When the Display Indicator has both `light-theme` and `dark-theme` set to `current`, changing the theme profile in the indicator will cause Ayatana Settings to change it's appearance to light/dark - without the need to change the theme.